### PR TITLE
[Feat/#8] : commandLineRunner를 이용하여 API 호출 응답 데이터를 DB에 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,13 +40,17 @@ dependencies {
     implementation 'com.mysql:mysql-connector-j:8.0.33'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    //gradle 5.x.x 이상 lombok 설정
     compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
     //yml파일 암호화 설정
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
 
     //Spring Open Feign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'io.github.openfeign:feign-gson:11.0'
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 

--- a/src/main/java/com/programmers/cat_picture_search/DataLoader.java
+++ b/src/main/java/com/programmers/cat_picture_search/DataLoader.java
@@ -1,0 +1,77 @@
+package com.programmers.cat_picture_search;
+
+import com.programmers.cat_picture_search.breed.entity.Breed;
+import com.programmers.cat_picture_search.breed.repository.BreedRepository;
+import com.programmers.cat_picture_search.feign.cat.dto.CatImage;
+import com.programmers.cat_picture_search.feign.cat.dto.CatImage.BreedDto;
+import com.programmers.cat_picture_search.image.controller.ImageController;
+import com.programmers.cat_picture_search.image.entity.Image;
+import com.programmers.cat_picture_search.image.repository.ImageRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DataLoader implements CommandLineRunner {
+
+  private final BreedRepository breedRepository;
+  private final ImageRepository imageRepository;
+  private final ImageController imageController;
+
+  // feignClient를 호출하여 Breed 데이터와 Image 데이터를 한꺼번에 저장한다.
+  @Override
+  public void run(String... args) throws Exception {
+    List<CatImage> images = imageController.getImages(50L);
+
+    for(CatImage image : images) {
+      List<String> breedIds = new ArrayList<>();
+
+      //1. breed정보를 저장함과 동시에 breedId만 따로 리스트에 저장한다.
+      List<BreedDto> breeds = image.getBreeds();
+      if(!breeds.isEmpty()) {
+        for (BreedDto breedDto : breeds) {
+          Breed savedBreed = Breed.builder()
+              .id(breedDto.getId())
+              .name(breedDto.getName())
+              .temperament(breedDto.getTemperament())
+              .origin(breedDto.getOrigin())
+              .build();
+
+          if (!breedRepository.existsById(savedBreed.getId())) {
+            breedIds.add(breedDto.getId());
+            breedRepository.save(savedBreed);
+          }
+        }
+
+        //2. breedId 리스트를 순회하며, 이미지 정보와 breedId를 각각 저장시킨다.
+        for (String breedId : breedIds) {
+          Image img = Image.builder()
+              .id(image.getId())
+              .url(image.getUrl())
+              .width(image.getWidth())
+              .height(image.getHeight())
+              .breed(breedRepository.getReferenceById(breedId))
+              .build();
+          imageRepository.save(img);
+        }
+      } else {
+        Image img2 = Image.builder()
+            .id(image.getId())
+            .url(image.getUrl())
+            .width(image.getWidth())
+            .height(image.getHeight())
+            .build();
+        imageRepository.save(img2);
+      }
+
+    }
+  }
+
+
+}
+
+
+

--- a/src/main/java/com/programmers/cat_picture_search/breed/entity/Breed.java
+++ b/src/main/java/com/programmers/cat_picture_search/breed/entity/Breed.java
@@ -1,9 +1,8 @@
 package com.programmers.cat_picture_search.breed.entity;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,11 +12,18 @@ import lombok.NoArgsConstructor;
 public class Breed {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+  private String id;
 
   private String name;
   private String temperament;
   private String origin;
+
+  @Builder
+  public Breed(String id, String name, String temperament, String origin) {
+    this.id = id;
+    this.name = name;
+    this.temperament = temperament;
+    this.origin = origin;
+  }
 
 }

--- a/src/main/java/com/programmers/cat_picture_search/breed/repository/BreedRepository.java
+++ b/src/main/java/com/programmers/cat_picture_search/breed/repository/BreedRepository.java
@@ -1,0 +1,9 @@
+package com.programmers.cat_picture_search.breed.repository;
+
+import com.programmers.cat_picture_search.breed.entity.Breed;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BreedRepository extends JpaRepository<Breed, String> {
+
+
+}

--- a/src/main/java/com/programmers/cat_picture_search/feign/cat/client/CatFeignClient.java
+++ b/src/main/java/com/programmers/cat_picture_search/feign/cat/client/CatFeignClient.java
@@ -1,11 +1,18 @@
 package com.programmers.cat_picture_search.feign.cat.client;
 
 import com.programmers.cat_picture_search.feign.cat.config.FeignConfig;
+import com.programmers.cat_picture_search.feign.cat.dto.CatImage;
+import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(name = "catFeignClient", url = "${the-cat-api.url}", configuration = FeignConfig.class)
+@FeignClient(name = "catFeignClient", url = "${the-cat-api.url}",
+             configuration = FeignConfig.class)
 public interface CatFeignClient {
 
+  @GetMapping(value = "v1/images/search")
+  List<CatImage> getImages(@RequestParam("limit") Long limit);
 
 }
 

--- a/src/main/java/com/programmers/cat_picture_search/feign/cat/config/FeignConfig.java
+++ b/src/main/java/com/programmers/cat_picture_search/feign/cat/config/FeignConfig.java
@@ -7,9 +7,8 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-
 @Configuration
-@EnableFeignClients("com.programmers.cat_picture_search")
+@EnableFeignClients(basePackages = "com.programmers.cat_picture_search")
 public class FeignConfig {
 
   @Bean

--- a/src/main/java/com/programmers/cat_picture_search/feign/cat/dto/CatImage.java
+++ b/src/main/java/com/programmers/cat_picture_search/feign/cat/dto/CatImage.java
@@ -1,0 +1,39 @@
+package com.programmers.cat_picture_search.feign.cat.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class CatImage {
+
+  /**
+   * 이미지의 String 아이디.
+   */
+  private String id;
+
+  /**
+   * 이미지 너비.
+   */
+  private Long width;
+
+  /**
+   * 이미지 높이.
+   */
+  private Long height;
+
+  /**
+   * 이미지 url.
+   */
+  private String url;
+
+  private List<BreedDto> breeds;
+
+  @Getter
+  public static class BreedDto {
+    private String id;
+    private String name;
+    private String temperament;
+    private String origin;
+  }
+
+}

--- a/src/main/java/com/programmers/cat_picture_search/feign/cat/dto/CatImage.java
+++ b/src/main/java/com/programmers/cat_picture_search/feign/cat/dto/CatImage.java
@@ -1,9 +1,13 @@
 package com.programmers.cat_picture_search.feign.cat.dto;
 
 import java.util.List;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@EqualsAndHashCode
+@ToString
 public class CatImage {
 
   /**

--- a/src/main/java/com/programmers/cat_picture_search/feign/cat/service/CatFeignService.java
+++ b/src/main/java/com/programmers/cat_picture_search/feign/cat/service/CatFeignService.java
@@ -1,0 +1,21 @@
+package com.programmers.cat_picture_search.feign.cat.service;
+
+import com.programmers.cat_picture_search.feign.cat.client.CatFeignClient;
+import com.programmers.cat_picture_search.feign.cat.dto.CatImage;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CatFeignService {
+
+  private final CatFeignClient catFeignClient;
+
+  public List<CatImage> getCatImages(Long limit) {
+    return catFeignClient.getImages(limit);
+  }
+
+}

--- a/src/main/java/com/programmers/cat_picture_search/image/controller/ImageController.java
+++ b/src/main/java/com/programmers/cat_picture_search/image/controller/ImageController.java
@@ -1,0 +1,26 @@
+package com.programmers.cat_picture_search.image.controller;
+
+import com.programmers.cat_picture_search.feign.cat.dto.CatImage;
+import com.programmers.cat_picture_search.feign.cat.service.CatFeignService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class ImageController {
+
+  private final CatFeignService catFeignService;
+
+  @GetMapping("/images")
+  public List<CatImage> getImages(@RequestParam("limit") Long limit) {
+    return catFeignService.getCatImages(limit);
+  }
+
+
+
+}

--- a/src/main/java/com/programmers/cat_picture_search/image/entity/Image.java
+++ b/src/main/java/com/programmers/cat_picture_search/image/entity/Image.java
@@ -4,11 +4,10 @@ import static jakarta.persistence.FetchType.*;
 
 import com.programmers.cat_picture_search.breed.entity.Breed;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,8 +17,7 @@ import lombok.NoArgsConstructor;
 public class Image {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+  private String id;
 
   private String url;
 
@@ -36,4 +34,13 @@ public class Image {
   @ManyToOne(fetch = LAZY)
   @JoinColumn(name = "breed_id")
   private Breed breed;
+
+  @Builder
+  public Image(String id, String url, Long width, Long height, Breed breed) {
+    this.id = id;
+    this.url = url;
+    this.width = width;
+    this.height = height;
+    this.breed = breed;
+  }
 }

--- a/src/main/java/com/programmers/cat_picture_search/image/repository/ImageRepository.java
+++ b/src/main/java/com/programmers/cat_picture_search/image/repository/ImageRepository.java
@@ -1,0 +1,9 @@
+package com.programmers.cat_picture_search.image.repository;
+
+import com.programmers.cat_picture_search.image.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, String> {
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,5 +24,7 @@ autocomplete:
   delimiter: §
 
 the-cat-api:
-  url: https://docs.thecatapi.com/
+  url: https://api.thecatapi.com/
   key: ${CAT_API_KEY}
+
+


### PR DESCRIPTION
## What is this PR? 🔍
CommandLineRunner를 이용하여 외부 API 호출 응답 데이터를 DB에 저장합니다.

## Key Changes 📝
- [X] FeignClient 관련 config, service, dto 생성
- [X] commandLineRunner를 구현한 DataLoader 클래스 생성
- [X] 엔티티의 고유값을 String으로 변경

## Test Checklist ✅
- Nothing

## To Reviewers
- DataLoader 클래스에서 리팩토링이 필요합니다.
