### PR TITLE
[Feat/#14] : response body 객체 생성

### DIFF
--- a/src/main/java/com/programmers/cat_picture_search/global/response/body/CommonResponse.java
+++ b/src/main/java/com/programmers/cat_picture_search/global/response/body/CommonResponse.java
@@ -1,0 +1,11 @@
+package com.programmers.cat_picture_search.global.response.body;
+
+import lombok.Getter;
+
+@Getter
+public class CommonResponse {
+  public boolean success;
+  public int code;
+  public String message;
+
+}

--- a/src/main/java/com/programmers/cat_picture_search/global/response/body/ListResponse.java
+++ b/src/main/java/com/programmers/cat_picture_search/global/response/body/ListResponse.java
@@ -1,0 +1,10 @@
+package com.programmers.cat_picture_search.global.response.body;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class ListResponse <T> extends CommonResponse {
+  public List<T> dataList;
+
+}

--- a/src/main/java/com/programmers/cat_picture_search/global/response/body/SingleResponse.java
+++ b/src/main/java/com/programmers/cat_picture_search/global/response/body/SingleResponse.java
@@ -1,0 +1,10 @@
+package com.programmers.cat_picture_search.global.response.body;
+
+import lombok.Getter;
+
+@Getter
+public class SingleResponse <T> extends CommonResponse {
+
+  public T data;
+
+}

--- a/src/main/java/com/programmers/cat_picture_search/global/response/service/ResponseService.java
+++ b/src/main/java/com/programmers/cat_picture_search/global/response/service/ResponseService.java
@@ -1,0 +1,34 @@
+package com.programmers.cat_picture_search.global.response.service;
+
+import com.programmers.cat_picture_search.global.response.body.CommonResponse;
+import com.programmers.cat_picture_search.global.response.body.ListResponse;
+import com.programmers.cat_picture_search.global.response.body.SingleResponse;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ResponseService {
+
+  public<T> SingleResponse<T> getSingleResponse(T data) {
+    SingleResponse singleResponse = new SingleResponse();
+    singleResponse.data = data;
+    setSuccessResponse(singleResponse);
+
+    return singleResponse;
+  }
+
+  public<T> ListResponse<T> getListResponse(List<T> dataList) {
+    ListResponse listResponse = new ListResponse();
+    listResponse.dataList = dataList;
+    setSuccessResponse(listResponse);
+
+    return listResponse;
+  }
+
+  void setSuccessResponse(CommonResponse commonResponse) {
+    commonResponse.code = 0;
+    commonResponse.success = true;
+    commonResponse.message = "SUCCESS";
+  }
+
+}


### PR DESCRIPTION
## What is this PR? 🔍
close feat / #14 
api 호출에 대한 일관성 있는 응답을 제공하기 위해 response 객체를 생성합니다.

## Key Changes 📝
- [X] 단건 조회, 목록 조회 관련 response body 객체 생성
- [X] response service 생성

## Test Checklist ✅
- Nothing

## To Reviewers
- 커스텀이 모두 완성되지 않았습니다. 이후에 에러코드 정의 등 추가 작업을 해줘야 합니다.