### PR TITLE
[Feat/#9] : 고양이 이미지 랜덤 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'org.springframework.boot' version '3.0.6'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
-    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.programmers'
@@ -54,16 +53,11 @@ dependencies {
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
-    //querydsl
-    implementation "com.querydsl:querydsl-jpa:jakarta"
-    implementation "com.querydsl:querydsl-core"
-    implementation "com.querydsl:querydsl-collections:"
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
-    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-    testImplementation 'jakarta.persistence:jakarta.persistence-api'
-    testImplementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    // == 스프링 부트 3.0 이상일 때, querydsl 의존성 ==
+    implementation("com.querydsl:querydsl-jpa:${dependencyManagement.importedProperties["querydsl.version"]}:jakarta")
+    annotationProcessor("com.querydsl:querydsl-apt:${dependencyManagement.importedProperties["querydsl.version"]}:jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
@@ -71,23 +65,30 @@ dependencies {
 
 }
 
-def querydslDir = "$buildDir/generated/querydsl"
-
-querydsl {
-    jpa = true
-    querydslSourcesDir = querydslDir
-}
-
 sourceSets {
-    main.java.srcDir querydslDir
+    main {
+        java {
+            srcDirs = ["$projectDir/src/main/java", "$projectDir/build/generated"]
+        }
+    }
 }
 
-configurations {
-    querydsl.extendsFrom compileClasspath
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
 }
 
-compileQuerydsl {
-    options.annotationProcessorPath = configurations.querydsl
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
 }
 
 tasks.named('test') {

--- a/src/main/java/com/programmers/cat_picture_search/DataLoader.java
+++ b/src/main/java/com/programmers/cat_picture_search/DataLoader.java
@@ -24,7 +24,7 @@ public class DataLoader implements CommandLineRunner {
   // feignClient를 호출하여 Breed 데이터와 Image 데이터를 한꺼번에 저장한다.
   @Override
   public void run(String... args) throws Exception {
-    List<CatImage> images = imageController.getImages(50L);
+    List<CatImage> images = imageController.getImages(100L);
 
     for(CatImage image : images) {
       List<String> breedIds = new ArrayList<>();

--- a/src/main/java/com/programmers/cat_picture_search/global/config/QuerydslConfig.java
+++ b/src/main/java/com/programmers/cat_picture_search/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.programmers.cat_picture_search.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+  @Autowired
+  private EntityManager em;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(em);
+  }
+}

--- a/src/main/java/com/programmers/cat_picture_search/image/controller/ImageController.java
+++ b/src/main/java/com/programmers/cat_picture_search/image/controller/ImageController.java
@@ -2,25 +2,34 @@ package com.programmers.cat_picture_search.image.controller;
 
 import com.programmers.cat_picture_search.feign.cat.dto.CatImage;
 import com.programmers.cat_picture_search.feign.cat.service.CatFeignService;
+import com.programmers.cat_picture_search.image.dto.response.ImageDto;
+import com.programmers.cat_picture_search.image.service.ImageService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class ImageController {
 
   private final CatFeignService catFeignService;
+  private final ImageService imageService;
 
+  //TODO: Feign controller 를 생성하여, 이 메서드를 넣기 & Feign 패키지 위치 모두 변경
   @GetMapping("/images")
   public List<CatImage> getImages(@RequestParam("limit") Long limit) {
     return catFeignService.getCatImages(limit);
   }
 
-
+  @GetMapping("/cats/random/50")
+  public List<ImageDto> getRandom50() {
+    return imageService.get50Images();
+  }
 
 }

--- a/src/main/java/com/programmers/cat_picture_search/image/dto/response/ImageDto.java
+++ b/src/main/java/com/programmers/cat_picture_search/image/dto/response/ImageDto.java
@@ -1,0 +1,19 @@
+package com.programmers.cat_picture_search.image.dto.response;
+
+import com.programmers.cat_picture_search.image.entity.Image;
+import lombok.Getter;
+
+@Getter
+public class ImageDto {
+  private final String id;
+  private final String url;
+  private final String name;
+
+  public ImageDto(Image image) {
+    this.id = image.getId();
+    this.url = image.getUrl();
+    //breed 정보 없으면 '품종 정보 없음' 으로 나타나야 함
+    this.name = image.getBreed() != null ? image.getBreed().getName() : "품종 정보 없음";
+  }
+
+}

--- a/src/main/java/com/programmers/cat_picture_search/image/repository/ImageRepository.java
+++ b/src/main/java/com/programmers/cat_picture_search/image/repository/ImageRepository.java
@@ -3,7 +3,7 @@ package com.programmers.cat_picture_search.image.repository;
 import com.programmers.cat_picture_search.image.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ImageRepository extends JpaRepository<Image, String> {
+public interface ImageRepository extends JpaRepository<Image, String>, ImageRepositoryCustom {
 
 
 }

--- a/src/main/java/com/programmers/cat_picture_search/image/repository/ImageRepositoryCustom.java
+++ b/src/main/java/com/programmers/cat_picture_search/image/repository/ImageRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.programmers.cat_picture_search.image.repository;
+
+import com.programmers.cat_picture_search.image.entity.Image;
+import java.util.List;
+
+public interface ImageRepositoryCustom {
+  List<Image> get50();
+
+}

--- a/src/main/java/com/programmers/cat_picture_search/image/repository/ImageRepositoryImpl.java
+++ b/src/main/java/com/programmers/cat_picture_search/image/repository/ImageRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.programmers.cat_picture_search.image.repository;
+
+import com.programmers.cat_picture_search.image.entity.Image;
+import com.programmers.cat_picture_search.image.entity.QImage;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ImageRepositoryImpl implements ImageRepositoryCustom {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Override
+  public List<Image> get50() {
+    QImage i = new QImage("i");
+    return jpaQueryFactory.selectFrom(i)
+        .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
+        .limit(50)
+        .fetch();
+  }
+}

--- a/src/main/java/com/programmers/cat_picture_search/image/service/ImageService.java
+++ b/src/main/java/com/programmers/cat_picture_search/image/service/ImageService.java
@@ -1,0 +1,25 @@
+package com.programmers.cat_picture_search.image.service;
+
+import com.programmers.cat_picture_search.image.dto.response.ImageDto;
+import com.programmers.cat_picture_search.image.entity.Image;
+import com.programmers.cat_picture_search.image.repository.ImageRepositoryImpl;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+  private final ImageRepositoryImpl imageRepositoryImpl;
+
+  //랜덤으로 50개 뽑아들고옴
+  public List<ImageDto> get50Images() {
+    List<Image> randomImg50 = imageRepositoryImpl.get50();
+
+    return randomImg50.stream()
+        .map(ImageDto::new)
+        .collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
## What is this PR? 🔍
고양이 이미지 50개를 랜덤으로 조회할 수 있는 목록을 보여줍니다.

## Key Changes 📝
- [X] cat API를 호출하여 100개의 데이터를 DB에 저장
- [X] 랜덤 이미지 조회하는 기능 관련 service, controller, dto 구현
- [X] querydsl 세팅 변경

## Test Checklist ✅
- Nothing

## To Reviewers
- Nothing
